### PR TITLE
experiments with rrr vectors in sdsl

### DIFF
--- a/deprec/rrr_sdsl/klcp.txt
+++ b/deprec/rrr_sdsl/klcp.txt
@@ -1,0 +1,53 @@
+seq_len 20415097628 (= number of bits)
+capacity 2551887204 (= number of bytes)
+
+ones count: 4460037689
+(22% load)
+
+10M random index access
+
+usual vector
+sum indexes counting time 0.004918 sec
+one element access time in usual vector 4.918e-10
+
+sum b = 2408441
+sum b counting time 0.497075 sec
+one element access time in bitvector 4.97075e-08
+size of b in MB: 2433.67
+
+block size 7
+sum rrrb = 2408441
+sum rrrb counting time 3.11384 sec
+one element access time in rrrvector 3.11384e-07
+size of rrrb in MB: 2521.71
+
+block size 15
+sum rrrb = 2408441
+sum rrrb counting time 1.738 sec
+one element access time in rrrvector 1.738e-07
+size of rrrb in MB: 2028.15
+
+block size 31
+sum rrrb = 2408441
+sum rrrb counting time 4.21351 sec
+one element access time in rrrvector 4.21351e-07
+size of rrrb in MB: 1874.11
+
+
+block size 63
+sum rrrb = 2408441
+sum rrrb counting time 5.04809 sec
+one element access time in rrrvector 5.04809e-07
+size of rrrb in MB: 1826.86
+
+block size 127
+sum rrrb = 2408441
+sum rrrb counting time 7.21965 sec
+one element access time in rrrvector 7.21965e-07
+size of rrrb in MB: 1814.86
+
+block size 255
+sum rrrb = 2388561
+sum rrrb counting time 14.1038 sec
+one element access time in rrrvector 1.41038e-06
+size of rrrb in MB: 1813.65

--- a/deprec/rrr_sdsl/random.txt
+++ b/deprec/rrr_sdsl/random.txt
@@ -1,0 +1,50 @@
+random array, size = 10G, ones = 100M, fillness 1/100
+
+sum indexes counting time 0.002962 sec
+one element access time in usual vector 2.962e-10
+
+sum b = 100683
+sum b counting time 0.240442 sec
+one element access time in bitvector 2.40442e-08
+size of b in MB: 1192.09
+
+block size 7
+sum rrrb = 100683
+sum rrrb counting time 0.615616 sec
+one element access time in rrrvector 6.15616e-08
+size of rrrb in MB: 849.648
+
+
+block size 15
+sum rrrb = 100683
+sum rrrb counting time 0.519449 sec
+one element access time in rrrvector 5.19449e-08
+size of rrrb in MB: 503.82
+
+
+block size 31
+sum rrrb = 100683
+sum rrrb counting time 1.03929 sec
+one element access time in rrrvector 1.03929e-07
+size of rrrb in MB: 318.729
+
+
+block size 63
+sum rrrb = 100683
+sum rrrb counting time 1.51388 sec
+one element access time in rrrvector 1.51387e-07
+size of rrrb in MB: 216.223
+
+
+block size 127
+sum rrrb = 100683
+sum rrrb counting time 2.20952 sec
+one element access time in rrrvector 2.20952e-07
+size of rrrb in MB: 160.445
+
+
+block size 255
+sum rrrb = 100683
+sum rrrb counting time 3.64752 sec
+one element access time in rrrvector 3.64752e-07
+size of rrrb in MB: 131.301

--- a/deprec/rrr_sdsl/test.cpp
+++ b/deprec/rrr_sdsl/test.cpp
@@ -1,0 +1,130 @@
+#include <sdsl/bit_vectors.hpp>
+#include <iostream>
+#include <time.h>
+
+using namespace std;
+using namespace sdsl;
+
+template<size_t size>
+void check_rrr_vector(bit_vector &b, int M, vector<int> random_indexes) {
+  rrr_vector<size> rrrb(b);
+  //rrr_vector<127>::rank_1_type rank_rrrb(&rrrb);
+
+  clock_t t = clock();
+  int sum_rrrb = 0;
+  for(int i = 0; i < M; ++i) {
+    sum_rrrb += rrrb[random_indexes[i]];;
+  }
+
+  float time = (float)(clock() - t) / CLOCKS_PER_SEC;
+  cout << endl;
+  cout << "block size " << size << endl;
+  cout << "sum rrrb = " << sum_rrrb << endl;
+  cout << "sum rrrb counting time " << time << " sec" << endl;
+  cout << "one element access time in rrrvector " << time / M << endl;
+  cout<< "size of rrrb in MB: " << size_in_mega_bytes(rrrb)<< endl;
+
+  // rrr_vector<i>::select_1_type select_rrrb(&rrrb);
+  // cout<<"position of first one in b: "<<select_rrrb(1)<<endl;
+  // cout << "size of select_rrrb in MB = " << size_in_mega_bytes(select_rrrb) << endl;
+  cout<<endl;
+}
+
+void check_compressed_vectors(bit_vector &b) {
+  int M = 10000000;
+  vector<int> random_indexes(M, 0);
+  for(int i = 0; i < M; ++i) {
+    random_indexes[i] = rand() % b.size();
+  }
+
+  clock_t t = clock();
+  int sum_indexes = 0;
+  for(int i = 0; i < M; ++i) {
+    sum_indexes += random_indexes[i];
+  }
+  float time = (float)(clock() - t) / CLOCKS_PER_SEC;
+  cout << "sum indexes = " << sum_indexes << endl;
+  cout << "sum indexes counting time " << time << " sec" << endl;
+  cout << "one element access time in usual vector " << time / M << endl;
+
+  t = clock();
+  int sum_b = 0;
+  for(int i = 0; i < M; ++i) {
+    sum_b += b[random_indexes[i]];
+  }
+  time = (float)(clock() - t) / CLOCKS_PER_SEC;
+  cout << "sum b = " << sum_b << endl;
+  cout << "sum b counting time " << time << " sec" << endl;
+  cout << "one element access time in bitvector " << time / M << endl;
+
+  //rank_support_v<> rb(&b);
+
+  cout<< "size of b in MB: " << size_in_mega_bytes(b)<< endl;
+  //cout<< "size of rb in MB: " << size_in_mega_bytes(rb)<< endl;
+
+  check_rrr_vector<7>(b, M, random_indexes);
+  check_rrr_vector<15>(b, M, random_indexes);
+  check_rrr_vector<31>(b, M, random_indexes);
+  check_rrr_vector<63>(b, M, random_indexes);
+  check_rrr_vector<127>(b, M, random_indexes);
+  check_rrr_vector<255>(b, M, random_indexes);
+}
+
+int main()
+{
+    srand(time(NULL));
+
+    uint64_t N = 10000000000;
+    bit_vector b(N, 0);
+    for(uint64_t i = 0; i < N; ++i) {
+      if (rand() % 100 == 3) {
+		    b[i] = 1;
+	    }
+    }
+    check_compressed_vectors(b);
+    return 0;
+
+    FILE *fp;
+	  fp = fopen("klcp_big.bin", "rb");
+    uint64_t seq_len;
+	  fread(&seq_len, sizeof(uint64_t), 1, fp);
+    uint64_t capacity = (seq_len + 7) / 8;
+    cout << "seq_len " << seq_len << endl;
+    cout << "capacity " << capacity << endl;
+    bit_vector klcp(seq_len, 0);
+    cout << "bitvector created" << std::endl;
+    FILE *log;
+    uint64_t ones = 0;
+    //log = fopen("klcp_log.txt", "w");
+    for(uint64_t i = 0; i < capacity; ++i) {
+      //fprintf(log, "%llu ", i);
+      int8_t element;
+      int a = fread(&element, sizeof(int8_t), 1, fp);
+      if (a != sizeof(int8_t)) {
+        cerr << "can not read" << std::endl;
+      }
+      //cout << (int)element << endl;
+      for(int j = 0; j < 8; ++j) {
+        klcp[i * 8 + j] = ((element & (1 << (j % 8))) > 0);
+        ones += klcp[i * 8 + j];
+      }
+    }
+    cout << "ones count: " << ones << endl;
+    // for(int i = 0; i < seq_len; ++i) {
+    //   cout << klcp[i] << endl;
+    // }
+    check_compressed_vectors(klcp);
+
+    //
+    // t = clock();
+    // int sum_rank_rrrb = 0;
+    // for(int i = 0; i < N; ++i) {
+    //   sum_rank_rrrb += rank_rrrb(i);
+    // }
+    //
+    // cout << "sum rank rrrb counting time " << (float)(clock() - t) / CLOCKS_PER_SEC << " sec" << endl;
+    // cout << "sum b = " << sum_b << ", sum rank rrrb = " << sum_rank_rrrb << endl;
+    // cout << "sum rrrb = " << sum_rrrb << endl;
+
+    //cout<< "size of rank_rrrb in MB: " << size_in_mega_bytes(rank_rrrb)<< endl;
+}


### PR DESCRIPTION
I made some experiments with rrr vectors from sdsl.
I added some test code (deprec/rrr_sdsl/test.cpp, @karel-brinda, maybe there is some better place for it?), where I construct bitvectors and rrr vectors for two types of initial data:
1) random vector on 10G elements, 100M of them are ones (so it is like our contig borders array) - results are in deprec/rrr_sdsl/random.txt
2) klcp array that Karel send to me (about 20G elements, 4G of them set to 1, about 22% load) - results are in deprec/rrr_sdsl/klcp.txt

How I made the experiments:
1) construct a usual random vector of 10M elements (let it be V), that I use as indexes to randomly access bitvector and rrr vector
2) measure time for accessing elements in bitvector at indexes from V
3) construct rrr vectors for different block size (block size characterizes how fast queries will be and how good the compression will be), I used block sizes from 8-1 to 256-1

for every vector, I output sum of elements on given indexes (to check that everything is correct), total time and time for accessing one element. I used vector V for indexes instead of just taking random indexes because I wanted to take the same indexes. This doesn't affect results, as I checked time for access usual vector V, and it is 3 orders of magnitude higher than even accessing a bitvector

Results for "random vector" a nice:
bitvector size is 1192MB, access time is 2.4e-8
rrr vectors size if from 850 MB (block size 7) to 131 MB (block size 255), and access times are from 6e-8 (7) to 3.6e-7 (255) (access times are per element)
So for block size = 255 size is almost 10 times smaller and access time is about 10 times slower, that's a good result, as for me

For klcp array results are much worse:
bitvector size is 2433MB, access time is 5e-08
rrr vectors size if from 2521 MB (block size 7) to 1813 MB (block size 255), and access times are from 3.1e-7 (7) to 1.4e-6 (255) (access times are per element)
Compressed rrr vector is up ti 25% smaller, with about 30 times slower queries
Moreover, for block size 255 I get wrong sum of queried elements, while everything is OK for other block sizes

I will continue experiments, maybe will find something better for klcp
